### PR TITLE
Remove the mention about jemalloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,10 +1102,6 @@ __Debug symbols__
 
 Rust programs compile with some debug symbols retained, even when compiling in release mode. These are used for providing backtraces on panics, and can be removed with `strip`, or another debug symbol removal tool. It is also useful to note that compiling in release mode with Cargo is equivalent to setting optimization level 3 with rustc. An alternative optimization level (called `s` or `z`) [has been added](https://github.com/rust-lang/rust/pull/32386) and tells the compiler to optimize for size rather than performance.
 
-__Jemalloc__
-
-Rust uses jemalloc as the default allocator, which adds some size to compiled Rust binaries. Jemalloc is chosen because it is a consistent, quality allocator that has preferable performance characteristics compared to a number of common system-provided allocators. There is work being done to [make it easier to use custom allocators](https://github.com/rust-lang/rust/issues/32838), but that work is not yet finished.
-
 __Link-time optimization__
 
 Rust does not do link-time optimization by default, but can be instructed to do so. This increases the amount of optimization that the Rust compiler can potentially do, and can have a small effect on binary size. This effect is likely larger in combination with the previously mentioned size optimizing mode.


### PR DESCRIPTION
[jemalloc is no longer default std allocator](https://internals.rust-lang.org/t/jemalloc-was-just-removed-from-the-standard-library/8759)